### PR TITLE
changes_2017/03/13

### DIFF
--- a/R/trialMinRand.R
+++ b/R/trialMinRand.R
@@ -3,9 +3,9 @@
 #' Provides a measure of treatment imbalance with respect to a desired ratio of
 #' treatments.
 #'
-#' @param treatments a factor containing a sequence of treatments.
+#' @param treatments a factor or a character/numeric vector containing a sequence of treatments.
 #' @param treatment.ratios a named vector containing the desired treatment ratios.
-#' By default, each treatment is given in the same frequency.
+#' Treatment.ratios should at least contain all unique elements of the treatments vector.
 #'
 #' @details
 #' A treatment vector has imbalance 0 if the treatments occur in the desired ratio.
@@ -13,32 +13,51 @@
 #' 
 #' @examples
 #' # A balanced treatment vector
-#' imbalance(factor(c("A","B","B","A"),levels=c("A","B")))
-#' # Still balanced if ratio is given as 50:50 instead of the default 1:1
+#' imbalance(factor(c("A","B","B","A"),levels=c("A","B")),treatment.ratios=c(A=1,B=1))
+#' # Still balanced if ratio is given as 50:50 instead of 1:1
 #' imbalance(factor(c("A","B","B","A"),levels=c("A","B")),treatment.ratios=c(A=50,B=50))
+#' # Treatments can also be provided as a numeric vector
+#' imbalance(c(1,2,2,1),treatment.ratios=c("1"=1,"2"=1))
+#' # Treatments can be provided as a character vector
+#' imbalance(c("A","B","B","A"), treatment.ratios=c(A=1,B=1))
 #' 
 #' @export
-imbalance <- function( treatments, treatment.ratios=setNames(rep(1,length(treatments)),levels(treatments)) ) {
+imbalance <- function( treatments, treatment.ratios ) {
+
+	#Check input	
 	.check.treatments( treatments )
 	.check.treatment.ratios( treatment.ratios )
-	xt <- table( treatments )
-	xt <- xt*.scm(treatment.ratios)/treatment.ratios[names(xt)]
-	diff(range(xt))
-}
+	.check.treatment.names( treatments, treatment.ratios )
 
-# Concatenate two factors to get a new factor.
-.c.fac <- function( ... ){
-	unlist( list( ... ) )
+	#Count how often each treatment occurs in the current vector.
+	#Add the treatments not in there to the table with a 'zero'.
+	xt <- setNames(rep(0,length(names(treatment.ratios))),names(treatment.ratios))
+	xt[names(table( treatments ))] <- table( treatments )
+
+	#Assign each treatment a weight such that multiplying the elements of treatment.ratios with the
+	#elements of treatment.weights yields an equal, integer number for all treatments. To get
+	#treatment.weights that are also integer, this number can be the smallest common multiple (scm)
+	#of the elements in treatment.ratios. Dividing the scm by the treatment.ratios vector then yields the
+	#vector with weights:
+	treatment.weights <- .scm(treatment.ratios)/treatment.ratios[names(xt)]
+
+	#Now multiply treatment counts with treatment weights. The difference of the range yields the (weighted)
+	#imbalance:
+	weighted.xt <- xt*treatment.weights
+	diff(range(weighted.xt))
 }
 
 # The greatest common divisor of a vector of integer numbers.
 .gcd <- function( x ){
+
+	#Calculate gcd with "Euclidian algorithm"
 	if( length(x) < 2 ){
 		return(x)
 	}
 	if( length(x) > 2 ){
 		return( .gcd( c( x[1], .gcd( x[-1] ) ) ) )
 	}
+
 	x <- sort(x)
 	xd <- diff(x)
 	if( xd==0 ){
@@ -58,23 +77,48 @@ imbalance <- function( treatments, treatment.ratios=setNames(rep(1,length(treatm
 	return( prod(x)  / .gcd(x) )
 }
 
-# Parameter check for treatment ratios:
-# All positive integers.
+# Format check for treatment ratios:
 .check.treatment.ratios <- function(x){
-	if( !all.equal( unname(x), as.integer(x) ) ){
+	if( !is.vector(x) ){
+		stop("treatment.ratios must be a vector!")
+	}
+	if( !is.numeric(x) ){
+		stop("treatment.ratios must be a (named) numeric vector!")
+	}
+	if( !all( unname(x) ==  as.integer(x) ) ){
 		stop("Please use integers to specify treatment ratios! (E.g., c(A=2,B=1) instead of c(A=1,B=0.5))")
 	}
 	if( any( x <= 0 ) ){
 		stop("Each treatment ratio must be positive!")
 	}
-}
-
-# Parameter check for the actual treatments.
-.check.treatments <- function(x){
-	if( !is.factor(x) ){
-		stop("treatments must be a factor!")
+	if( is.null(names(x)) ){
+		stop("The vector treatment.ratios must be named after the treatments! (E.g., c(A=2,B=1) instead of c(1,2))")
 	}
 }
+
+# Format check for the actual treatments.
+.check.treatments <- function(x){
+	if( !is.vector(x) & !is.factor(x) ){
+		stop("treatments must be a vector or a factor!")
+	}
+}
+
+# Last check: names in treatment.ratios must correspond to the actual treatment names. 
+.check.treatment.names <- function(treatments,treatment.ratios){
+
+	tnames <- names(treatment.ratios)
+	if(any(!is.element(treatments,tnames))){
+		stop("Not all treatments can be found in treatment.ratios. Please check that treatments are spelled correctly and that treatment.ratios is complete.")
+	}
+	if(is.factor(treatments)){
+		if(any(!is.element(levels(treatments),tnames))){
+			stop("Treatment is a factor, but levels do not correspond to the names in treatment.ratios.")
+		}
+	}	
+
+}
+
+
 
 #' @importFrom stats runif setNames
 #' @importFrom utils tail
@@ -90,8 +134,10 @@ NULL
 #' new patient, who will receive the next treatment. Strata can be given
 #' as a factor, or as columns that can be interpreted as a factor.
 #' 
-#' @param previous.treatments a factor containing the previous treatments.
-#' This factor should contain
+#' @param previous.treatments a factor or numeric/character vector containing 
+#' the previous treatments. 'previous.treatments' should have an element for
+#' each row in patient.data except the last (which represents the current patient
+#' for whom no treatment has been determined yet). 
 #'
 #' @param treatment.ratios a named vector containing the desired ratios
 #' in which treatments are to be given.
@@ -107,39 +153,51 @@ NULL
 #' # Define previous treatments
 #' tr <- factor( c("A","A"), levels=c("A","B") )
 #' # Call function to obtain next treatment
-#' next.tr <- assign.next.treatment( d, tr, c(A=2,B=1) )
+#' next.tr <- assign.next.treatment( d, c(A=2,B=1), tr )
 #'
 #' @export
 assign.next.treatment <- function(
-	patient.data, previous.treatments, treatment.ratios=NULL, p=0.3 ){
-	# Process and check input.
-	if( !is.factor(previous.treatments) ){
-		stop("previous.treatments must be a factor with >= 2 levels!")
+	patient.data, treatment.ratios, previous.treatments=character(0), p=0.3 ){
+	
+	# CHECK INPUT:
+	# patient.data must be a dataframe.
+	if (class(patient.data)!="data.frame"){
+		stop("patient.data must be a dataframe with at least one row!")
 	}
-	if( nlevels(previous.treatments) < 2 ){
-		stop("previous.treatments must be a factor with >= 2 levels!")
+
+	if ( nrow(patient.data) == 0 ){
+		stop("patient.data must be a dataframe with at least one row!")
 	}
-	if( length(previous.treatments) != nrow(patient.data)-1 ){
-		stop("The number of treatments must equal the number of patients - 1!")
-	}
+
+	# treatment.ratios should be a named vector of non-negative integers.
 	.check.treatment.ratios( treatment.ratios )
 
-	treatments <- as.factor(levels(previous.treatments))
-	N <- length(treatments)
+	# previous.treatments should be a vector of length nrow(patient.data) -1 and
+	# should only contain treatments specified in the treatment.ratios vector.
+	.check.treatments( previous.treatments )
+	previous.treatments <- as.character(previous.treatments)
 
-	if( is.null( treatment.ratios ) ){
-		treatment.ratios <- setNames(rep(1,N),levels(previous.treatments))
+	if( length(previous.treatments) != nrow(patient.data)-1 ){
+		stop(paste("The number of previous treatments must equal the number of patients - 1! Input data has",length(previous.treatments),"previous treatments and",nrow(patient.data),"patients."))
 	}
+	.check.treatment.names( previous.treatments, treatment.ratios )
+	
+
+	# CALCULATION
+	treatments <- names(treatment.ratios)
+	N <- length(treatments)
 
 	# Compute the total imbalances for each treatment.
 	factors <- names(patient.data)
 	imbalances <- sapply( treatments, function(tr){ 
 		sum( sapply( factors, function(f){
 			f.values <- patient.data[[f]]
-			imbalance(.c.fac(previous.treatments,tr)[f.values==tail(f.values,1)],
+			imbalance( c(previous.treatments,tr)[f.values==tail(f.values,1)],
 				treatment.ratios)
-		} ) ) } )
+			} ) ) 
+	} )
 
+	# OUTPUT
 	if( runif(1) > p ){
 		# Sort treatments in increasing order by imbalance, randomly breaking ties.
 		treatments <- treatments[order(imbalances, sample(N))]
@@ -148,7 +206,7 @@ assign.next.treatment <- function(
 	} else {
 		# Pick treatment at random, using biased coin to attain desired
 		# treatment ratio.
-		r <- sample( treatments, 1, prob=treatment.ratios[treatments] )
+		r <- sample( treatments, 1, prob=treatment.ratios[as.character(treatments)] )
 	}
 	r
 }

--- a/tests/testthat/test-imbalance.R
+++ b/tests/testthat/test-imbalance.R
@@ -1,17 +1,157 @@
-test_that("imbalance measure is 0 for balanced vectors",{
-	expect_equal(imbalance(factor(c("A","B","B","A"),levels=c("A","B"))),0)
-	expect_equal(imbalance(factor(c("A","B","B","A"),levels=c("A","B")),treatment.ratios=c(A=50,B=50)),0)
-	expect_equal(imbalance(factor(c("A","B","A","B","A","A"),levels=c("A","B")),treatment.ratios=c(A=2,B=1)),0)
-	expect_equal(imbalance(factor(c("A","B","A","B","A","A"),levels=c("B","A")),treatment.ratios=c(A=2,B=1)),0)
-	expect_equal(imbalance(factor(c("A","B","A","B","A","A"),levels=c("B","A")),treatment.ratios=c(A=100,B=50)),0)
-	expect_equal(imbalance(factor(c(1,2,2,1,2,2),levels=c(2,1)),treatment.ratios=c('1'=1,'2'=2)),0)
+# Test for correct format of the input data:
+# ---------------------
+
+# Check that all required inputs are there
+test_that("imbalance returns an error when not all required inputs are specified.",{
+	expect_error(imbalance())
+	expect_error(imbalance(c("A","B","B","A")))
+	expect_error(imbalance(treatment.ratios=c(A=1,B=2)))
+	expect_error(imbalance(c(A=1,B=2)))
 })
 
+# Check that inputs are of the right structure (if not, there should be erros from .check.treatments() and .check.treatment.ratios()
+test_that("imbalance returns an error when inputs are not in the correct format.",{
+
+	# Errors if treatments is not a vector 
+		expect_error(imbalance(matrix(2,2,2),treatment.ratios=c(A=1,B=2)),
+			"treatments must be a vector or a factor!")
+
+	# Errors if treatment.ratios is unnamed, not a numeric vector 
+	# or has non-integer/negative values:
+		expect_error(imbalance(c("A","B","B","A"), matrix(1,3,3)),
+			"treatment.ratios must be a vector!")
+		expect_error(imbalance(c("A","B","B","A"), c(A="a",B="b")))
+		expect_error(imbalance(c("A","B","B","A"), c(A="1",B="2")))
+		expect_error(imbalance(c("A","B","B","A"), c(1,1)),
+			"The vector treatment.ratios must be named after the treatments!")
+		expect_error(imbalance(c("A","B","B","A"), c(A=1,B=0.25)),
+			"Please use integers to specify treatment ratios!")
+		expect_error(imbalance(c("A","B","B","A"), c(A=3.25,B=1)),
+			"Please use integers to specify treatment ratios!")
+		expect_error(imbalance(c("A","B","B","A"), c(A=1,B=-2)),
+			"Each treatment ratio must be positive!")
+})
+
+# Check that elements in 'treatments' correspond to the names of 'treatment.ratios'
+test_that("all elements in 'treatments' are present in 'treatment.ratios' ",{
+
+	# Different treatment names in 'treatments' vs 'treatment.ratios'
+		expect_error(imbalance(c(1,2,2,4),c(A=1,B=1,C=1)),
+			"Not all treatments can be found in treatment.ratios.")
+	
+	# There is a treatment that is absent from 'treatment.ratios'
+		expect_error(imbalance(c(1,2,2,4),c("1"=1,"2"=1)),
+			"Not all treatments can be found in treatment.ratios.")
+		expect_error(imbalance(c("banana","apple","banana","apple","pear"),c(apple=1,banana=1)),
+			"Not all treatments can be found in treatment.ratios.")
+
+	# Treatments is a factor, but the levels do not correspond to names of treatment.ratios
+		expect_error(imbalance(factor(c(1,2,2,1),levels=c(1,2,3)),c("1"=1,"2"=2)))
+})
+
+
+# Test for correct output format
+# ---------------------
+test_that("Output is numeric and has length 1",{
+	expect_equal(is.numeric(imbalance(c("apple"),c(apple=1,banana=1))),TRUE)
+	expect_equal(is.numeric(imbalance(factor(c("A","B","B","A"),levels=c("A","B")),
+		treatment.ratios=c(A=1,B=1))),TRUE)
+	expect_length(imbalance(c("placebo","placebo","X","placebo","X"),c(placebo=1,X=2)),1)
+	expect_length(imbalance(c(3,4,3,3,4,5),c("3"=1,"5"=1,"4"=1)),1)
+})
+
+
+# Test for function calls that should be equivalent
+# ---------------------
+
+
+#Encoding type of treaments as factor() character() or numeric() doesn't matter
+test_that("Encoding type of treatments ( - eg as numeric(), factor() or character() ) does not affect the output.",{
+	expect_equal(imbalance(factor(c("A","B","B","A"),levels=c("A","B")),treatment.ratios=c(A=1,B=1)),
+		imbalance(factor(c(2,1,1,2),levels=c(2,1)),treatment.ratios=c("1"=1,"2"=1)))
+	expect_equal(imbalance(c(1,2,3,2), treatment.ratios=c("1"=1,"2"=2,"3"=3)),
+		imbalance(c("apple","pear","banana","pear"), treatment.ratios=c(apple=1,pear=2,banana=3)))	
+})
+
+
+#Output not changed when treatment.ratios is multiplied with a constant value:
+test_that("multiplying all values in treatment.ratios with a constant does not alter output",{
+	expect_equal(imbalance(factor(c("A","B","B","A"),levels=c("A","B")),treatment.ratios=c(A=1,B=1)),
+		imbalance(factor(c("A","B","B","A"),levels=c("A","B")),treatment.ratios=c(A=50,B=50)))
+	expect_equal(imbalance(c(2,1,1,2),treatment.ratios=c("1"=1,"2"=2)),
+		imbalance(c(2,1,1,2), treatment.ratios=c("1"=4,"2"=8)))
+	expect_equal(imbalance(c("pear","apple","pear"), treatment.ratios=c("pear"=2,"apple"=3)),
+		imbalance(c("pear","apple","pear"), treatment.ratios=c("pear"=40,"apple"=60)))
+	expect_equal(imbalance(c("pear"), treatment.ratios=c("pear"=4,"apple"=1)),
+		imbalance(c("pear"), treatment.ratios=c("pear"=40,"apple"=10)))
+})
+
+#Output not changed when treatments have a different order within 'treatments' vector
+test_that("Changing the order of the treatments within the treatments vector does not alter output",{
+	expect_equal(imbalance(factor(c("A","B","B","A"),levels=c("A","B")),treatment.ratios=c(A=1,B=1)),
+		imbalance(factor(c("A","A","B","B"),levels=c("A","B")),treatment.ratios=c(A=1,B=1)))
+	expect_equal(imbalance(factor(c("A","B","B","A"),levels=c("A","B")),treatment.ratios=c(A=1,B=1)),
+		imbalance(factor(c("A","B","A","B"),levels=c("A","B")),treatment.ratios=c(A=1,B=1)))
+	expect_equal(imbalance(c("pear","apple","pear"), treatment.ratios=c("pear"=2,"apple"=3)),
+		imbalance(c("pear","pear","apple"), treatment.ratios=c("pear"=2,"apple"=3)))
+	expect_equal(imbalance(c(1,2,1,2,1),treatment.ratios=c("1"=1,"2"=5)),
+		imbalance(c(2,2,1,1,1),treatment.ratios=c("1"=1,"2"=5)))
+})
+
+#Output not changed when order of treatments is changed within treatment.ratios
+test_that("Changing the order of the treatments within treatment.ratios does not alter output",{
+	expect_equal(imbalance(factor(c("A","B","B","A"),levels=c("A","B")),treatment.ratios=c(A=1,B=2)),
+		imbalance(factor(c("A","B","B","A"),levels=c("A","B")),treatment.ratios=c(B=2,A=1)))
+	expect_equal(imbalance(c("pear","apple","pear"), treatment.ratios=c("pear"=2,"apple"=3)),
+		imbalance(c("pear","apple","pear"), treatment.ratios=c("apple"=3,"pear"=2)))
+	expect_equal(imbalance(c(1,2,1,2,1),treatment.ratios=c("1"=1,"2"=5)),
+		imbalance(c(1,2,1,2,1),treatment.ratios=c("2"=5,"1"=1)))
+	expect_equal(imbalance(c("placebo","placebo","X","placebo","X"),c(placebo=1,X=2)),
+		imbalance(c("placebo","placebo","X","placebo","X"),c(X=2,placebo=1)))
+})
+
+#In a 1:1 ratio, it doesn't matter which treatment is present less
+test_that("In a 1:1 ratio, it it doesn't matter which treatment is present less.",{
+	expect_equal(imbalance(factor(c("A","B","B"),levels=c("A","B")),treatment.ratios=c(A=1,B=1)),
+		imbalance(factor(c("A","A","B"),levels=c("A","B")),treatment.ratios=c(B=1,A=1)))
+	expect_equal(imbalance(c("pear"), treatment.ratios=c("pear"=3,"apple"=3)),
+		imbalance(c("apple"), treatment.ratios=c("pear"=3,"apple"=3)))
+	expect_equal(imbalance(c(1,2,2,2), treatment.ratios=c("2"=50,"1"=50)),
+		imbalance(c(1,2,1,1), treatment.ratios=c("2"=50,"1"=50)))
+})
+
+
+# Test for specific output values
+# ---------------------
+
+# Function imbalance should return an imbalance of 0 when the vector is balanced. 
+test_that("imbalance measure is 0 for balanced vectors",{
+	expect_equal(imbalance(factor(c("A","B","B","A"),levels=c("A","B")),treatment.ratios=c(A=1,B=1)),0)
+	expect_equal(imbalance(factor(c("A","B","A","B","A","A"),levels=c("A","B")),treatment.ratios=c(A=2,B=1)),0)
+	expect_equal(imbalance(factor(c(1,2,2,1,2,2,2,2,1),levels=c(2,1)),treatment.ratios=c('1'=1,'2'=2)),0)
+	expect_equal(imbalance(c("placebo","X","X","placebo","X"),treatment.ratios=c(placebo=2,X=3)),0)
+})
+
+# Imbalance is not 0 for unbalanced vectors
 test_that("imbalance measures for unbalanced vectors",{
-	expect_equal(imbalance(factor(c("A","B","B"),levels=c("A","B"))),1)
-	expect_equal(imbalance(factor(c("B","B","A"),levels=c("A","B"))),1)
+	expect_equal(imbalance(factor( c("A","B","B") ,levels=c("A","B") ), treatment.ratios=c(A=1,B=1)),1)
+	expect_equal(imbalance(factor( c("B","B","A"), levels=c("A","B") ), treatment.ratios=c(A=1,B=1)),1)
 	expect_equal(imbalance(factor( c("A","B"), levels=c("B","A") ), treatment.ratios=c(A=2,B=1)),1)
 	expect_equal(imbalance(factor( c("A","B"), levels=c("A","B") ), treatment.ratios=c(A=3,B=4)),1)
 	expect_equal(imbalance(factor( c("A","B"), levels=c("B","A") ), treatment.ratios=c(A=1,B=5)),4)
 	expect_equal(imbalance(factor( c("A","B","B"), levels=c("A","B","C") ), treatment.ratios=c(A=2,B=3,C=5)),20)
+})
+
+
+##OTHER:
+# ---------------------
+
+# Not all the treatments in the treatment.ratios have to be present in 'treatments'. 
+test_that("Not all treatments need to be present in the treatments vector",{
+		expect_equal(imbalance(c("apple"),c(apple=1,banana=1)),1)
+		expect_equal(imbalance(c("apple"),c(banana=1,apple=1)),1)
+		expect_equal(imbalance(c("banana"),c(banana=1,apple=1)),1)
+		expect_equal(imbalance(factor(c(1,2,2,1),levels=c(1,2,3)),c("1"=1,"2"=1,"3"=1)),2)
+		expect_equal(imbalance(factor(c(1,2,2,1),levels=c(1,2,3)),c("2"=1,"1"=1,"3"=1)),2)
+		expect_equal(imbalance(c(1,2,2,1),c("2"=1,"1"=1,"3"=1)),2)
 })


### PR DESCRIPTION
##--- CODE:
1. Fixed bug that the order of treatments in treatment.ratios influenced the result: assign.next.treatment now converts 'previous.treatments' to a character vector before calculating imbalance, to avoid unexpected behaviour of factors and problems with concatenation.

2. Removed default for treatment.ratios in the functions imbalance and assign.next.treatment. This forces the user to specify all possible treatments in treatment.ratios, which prevents a situation where at treatment never gets assigned because it wasn't present in the input. (Wrong input of the treatment.ratios is very unlikely, whereas forgetting to add levels to a factor might happen more often).

3. Because of 2), it is now not necessary to specify previous.treatments in a factor. Encoding in a character or even a numeric vector is now allowed, as long as all treatments in this vector correspond to the names in treatment.ratios.

4. Altered .check.treatments() so that it also allows vectors of another type than factor.

5. Altered .check.treatment.ratios() to also check that:
	- treatment.ratios is a vector
	- treatment.ratios is numeric
	- treatment.ratios is named.

6. Added a function  .check.treatment.names() which checks that:
	- any treatments in previous.treatments correspond to one of the names of treatment.ratios
	- if previous.treatments is a factor, the levels of this factor should all correspond to one of the
	  names in treatment.ratios

7. Removed function .c.fac(), which is no longer required now that factors are internally converted to character() (see 1) ).

8. Fixed a bug in imbalance(): when treatments are not specified as a factor and not all treatments have been assigned yet, table() only returns counts for the treatments assigned so far (and does not assign count=0 to any remaining treatments). This would yield a value of 0 for the imbalance. Bug fixed by beginning with an 'empty' table with 0s for all treatments in treatment.ratios, and adding the counts from table() to this.

9. Updated the documentation for imbalance() and assign.next.treatment()

##--- TESTS:
test-imbalance.R modified:

1. Added tests to check input:
	- errors returned if no input is specified
	- errors returned if input doesn't satisfy .check.treatments(), .check.treatment.ratios(), .check.treatment.names()

2. Added test to check the output format:
	- output should always be numeric of length 1. (This test should fail if imbalance() ever returns NA, which is a logical instead of numeric).

3. Added tests for function calls that should be equivalent:
	- imbalance() should return the same result if treatments are specified as factor(), numeric()  or character()
	- imbalance() should return the same result if all values in treatment.ratios are multiplied with a constant (eg. 1:1 is the same as 3:3)
	- imbalance() should return the same result if the order in the treatment vector changes.
	- imbalance() should return the same result if the order in treatment.ratios changes
	- For a 1:1 treatment.ratio, imbalance is not influenced by WHICH treatment is present less -  as long as the counts stay the same.

4. Added tests for specific output values:
	- balanced treatment vectors (of any type: factor, numeric, character) should return imbalance=0.
	- unbalanced treatment vectors of any type should return a non-zero imbalance.

5. Added test to check that function still works if not all treatments have been assigned yet.

Added test-assignment.R:

NOTE: all tests of assign.next.treatment() that are based on a value use p=0 to avoid randomness in treatment assignment.

1. Added tests to check input:
	- errors returned if no input is specified
	- errors returned if either patient.data or treatment.ratios is missing  (note that previous.treatments has a default=character(0), which will work in a situation where patient.data has only one row. If this is not the case, there will be an error because the number  of treatments is not compatible with the number of lines in patient.data)
	- errors returned if patient.data is not a dataframe of at least one row
	- errors returned if input doesn't satisfy the .check.treatments(), .check.treatment.ratios()

2. Added test to check input compatibility:
	- errors returned if nrow(patient.data) != length(previous.treatments)
	- errors if input does not satisfy .check.treatment.names()

3. Added test to check the output format:
	- output should be character of length 1. (This test should fail if imbalance() ever returns NA.)

4. Added tests for function calls that should be equivalent:
	- result should stay the same if treatment.ratios is multiplied with a constant (50:100 vs 1:2)
	- result should stay the same if elements of treatment.ratios are in a different order
	- result should stay the same if previous patients are ordered differently (reorder previous.treatments and all but the last row of patient.data in the same way).

5. Added tests for specific output values:
	- trivial examples in which one treatment has not been assigned to any patient yet
	- trivial examples in which two treatments have so far not been assigned, but one of them  has a higher weight in treatment.ratios
	- check that even when there is no imbalance (and the choice is thus random), the chosen treatment is still one of those from treatment.ratios
	- example from the paper describing the minimization method should give the result described there.